### PR TITLE
Need to cast to json to work.

### DIFF
--- a/v1/sqlx-runner/json_test.go
+++ b/v1/sqlx-runner/json_test.go
@@ -10,13 +10,13 @@ import (
 func TestRealJSON(t *testing.T) {
 	j, _ := dat.NewJSON([]int{1, 2, 3})
 	var num int
-	conn.SQL("select $1->1", j).QueryScalar(&num)
+	conn.SQL("select $1::json->1", j).QueryScalar(&num)
 	assert.Equal(t, 2, num)
 }
 
 func TestRealJSONInterpolated(t *testing.T) {
 	j, _ := dat.NewJSON([]int{1, 2, 3})
 	var num int
-	conn.SQL("select $1->1", j).SetIsInterpolated(true).QueryScalar(&num)
+	conn.SQL("select $1::json->1", j).SetIsInterpolated(true).QueryScalar(&num)
 	assert.Equal(t, 2, num)
 }


### PR DESCRIPTION
My tests fail on postgres 9.4.1 unless the string is cast to json.

```
15:58:05.739718 ERR dat:sqlx QueryScalar.load_value.query
   err: pq: cannot cast type integer to json sql: select '[1,2,3]'->1::json
   args: nil
```