### PR TITLE
Write identifiers in update statements

### DIFF
--- a/update.go
+++ b/update.go
@@ -165,7 +165,7 @@ func (b *UpdateBuilder) ToSQL() (string, []interface{}) {
 	var args []interface{}
 
 	buf.WriteString("UPDATE ")
-	buf.WriteString(b.table)
+	writeIdentifier(buf, b.table)
 	buf.WriteString(" SET ")
 
 	var placeholderStartPos int64 = 1

--- a/update_test.go
+++ b/update_test.go
@@ -23,24 +23,24 @@ func BenchmarkUpdateValueMapSql(b *testing.B) {
 func TestUpdateAllToSql(t *testing.T) {
 	sql, args := Update("a").Set("b", 1).Set("c", 2).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1, %s = $2", "b", "c"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "b", "c"))
 	assert.Equal(t, args, []interface{}{1, 2})
 }
 
 func TestUpdateSingleToSql(t *testing.T) {
 	sql, args := Update("a").Set("b", 1).Set("c", 2).Where("id = $1", 1).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1, %s = $2 WHERE (id = $3)", "b", "c"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "b", "c"))
 	assert.Equal(t, args, []interface{}{1, 2, 1})
 }
 
 func TestUpdateSetMapToSql(t *testing.T) {
 	sql, args := Update("a").SetMap(map[string]interface{}{"b": 1, "c": 2}).Where("id = $1", 1).ToSQL()
 
-	if sql == quoteSQL("UPDATE a SET %s = $1, %s = $2 WHERE (id = $3)", "b", "c") {
+	if sql == quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "b", "c") {
 		assert.Equal(t, args, []interface{}{1, 2, 1})
 	} else {
-		assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1, %s = $2 WHERE (id = $3)", "c", "b"))
+		assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "c", "b"))
 		assert.Equal(t, args, []interface{}{2, 1, 1})
 	}
 }
@@ -48,19 +48,19 @@ func TestUpdateSetMapToSql(t *testing.T) {
 func TestUpdateSetExprToSql(t *testing.T) {
 	sql, args := Update("a").Set("foo", 1).Set("bar", Expr("COALESCE(bar, 0) + 1")).Where("id = $1", 9).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1, %s = COALESCE(bar, 0) + 1 WHERE (id = $2)", "foo", "bar"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = COALESCE(bar, 0) + 1 WHERE (id = $2)`, "foo", "bar"))
 	assert.Equal(t, args, []interface{}{1, 9})
 
 	sql, args = Update("a").Set("foo", 1).Set("bar", Expr("COALESCE(bar, 0) + $1", 2)).Where("id = $1", 9).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1, %s = COALESCE(bar, 0) + $2 WHERE (id = $3)", "foo", "bar"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = COALESCE(bar, 0) + $2 WHERE (id = $3)`, "foo", "bar"))
 	assert.Equal(t, args, []interface{}{1, 2, 9})
 }
 
 func TestUpdateTenStaringFromTwentyToSql(t *testing.T) {
 	sql, args := Update("a").Set("b", 1).Limit(10).Offset(20).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1 LIMIT 10 OFFSET 20", "b"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1 LIMIT 10 OFFSET 20`, "b"))
 	assert.Equal(t, args, []interface{}{1})
 }
 
@@ -75,7 +75,7 @@ func TestUpdateWhitelist(t *testing.T) {
 		SetWhitelist(sr, "user_id", "other").
 		ToSQL()
 
-	assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1, %s = $2", "user_id", "other"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "user_id", "other"))
 	checkSliceEqual(t, args, []interface{}{2, false})
 }
 
@@ -85,13 +85,13 @@ func TestUpdateBlacklist(t *testing.T) {
 		SetBlacklist(sr, "something_id").
 		ToSQL()
 
-	assert.Equal(t, sql, quoteSQL("UPDATE a SET %s = $1, %s = $2", "user_id", "other"))
+	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "user_id", "other"))
 	checkSliceEqual(t, args, []interface{}{2, false})
 }
 
 func TestUpdateWhereExprSql(t *testing.T) {
 	expr := Expr("id=$1", 100)
 	sql, args := Update("a").Set("b", 10).Where(expr).ToSQL()
-	assert.Equal(t, sql, `UPDATE a SET "b" = $1 WHERE (id=$2)`)
+	assert.Equal(t, sql, `UPDATE "a" SET "b" = $1 WHERE (id=$2)`)
 	assert.Exactly(t, args, []interface{}{10, 100})
 }

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -17,7 +17,7 @@ func TestUpsertSQLWhere(t *testing.T) {
 	expected := `
 	WITH
 		upd AS (
-			UPDATE tab
+			UPDATE "tab"
 			SET "b" = $1, "c" = $2
 			WHERE (d=$3)
 			RETURNING "b","c"
@@ -39,7 +39,7 @@ func TestUpsertSQLReturning(t *testing.T) {
 	expected := `
 	WITH
 		upd AS (
-			UPDATE tab
+			UPDATE "tab"
 			SET "b" = $1, "c" = $2
 			WHERE (d=$3)
 			RETURNING "f","g"
@@ -72,7 +72,7 @@ func TestUpsertSQLRecord(t *testing.T) {
 	expected := `
 	WITH
 		upd AS (
-			UPDATE tab
+			UPDATE "tab"
 			SET "b" = $1, "c" = $2
 			WHERE (d=$3)
 			RETURNING "f","g"


### PR DESCRIPTION
Updates were just writing table names as raw strings, which means they
failed with table names that conflicted with identifiers. This updates
the `UpdateBuilder` to write the table name as an identifier.

Also updates tests.