### PR TITLE
Consistent formatting of Time between pq driver and dat Interpolate

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -1,6 +1,10 @@
 package dat
 
-import "gopkg.in/mgutz/dat.v1/common"
+import (
+	"time"
+
+	"gopkg.in/mgutz/dat.v1/common"
+)
 
 // Dialect is the active SQLDialect.
 var Dialect SQLDialect
@@ -11,4 +15,6 @@ type SQLDialect interface {
 	WriteStringLiteral(buf common.BufferWriter, value string)
 	// WriteIdentifier writes a quoted identifer such as a column or table.
 	WriteIdentifier(buf common.BufferWriter, column string)
+	// WriteFormattedTime writes a time formatted for the database
+	WriteFormattedTime(buf common.BufferWriter, t time.Time)
 }

--- a/interpolate.go
+++ b/interpolate.go
@@ -115,12 +115,6 @@ func Interpolate(sql string, vals []interface{}) (string, []interface{}, error) 
 		if val, ok := v.(UnsafeString); ok {
 			buf.WriteString(string(val))
 			return nil
-		} else if us, ok := v.(UnsafeStringer); ok {
-			s, err := us.UnsafeString()
-			if err == nil {
-				buf.WriteString(string(s))
-				return nil
-			}
 		} else if _, ok := v.(JSON); ok {
 			passthroughArg()
 			return nil

--- a/interpolate.go
+++ b/interpolate.go
@@ -181,7 +181,7 @@ func Interpolate(sql string, vals []interface{}) (string, []interface{}, error) 
 		} else if kindOfV == reflect.Struct {
 			if typeOfV := valueOfV.Type(); typeOfV == typeOfTime {
 				t := valueOfV.Interface().(time.Time)
-				Dialect.WriteStringLiteral(buf, t.UTC().Format(timeFormat))
+				Dialect.WriteFormattedTime(buf, t)
 			} else {
 				return ErrInvalidValue
 			}

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -164,7 +164,7 @@ func TestInterpolatingTime(t *testing.T) {
 
 	str, _, err := Interpolate("SELECT * FROM x WHERE a = $1 AND b = $2 AND c = $3", args)
 	assert.NoError(t, err)
-	assert.Equal(t, str, "SELECT * FROM x WHERE a = NULL AND b = '0001-01-01 00:00:00Z' AND c = '2004-01-01 01:01:01Z'")
+	assert.Equal(t, "SELECT * FROM x WHERE a = NULL AND b = '0001-01-01T00:00:00Z' AND c = '2004-01-01T01:01:01.000000001Z'", str)
 }
 
 func TestInterpolateErrors(t *testing.T) {

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -196,15 +196,18 @@ func TestInterpolateJSON(t *testing.T) {
 }
 
 func TestInterpolateInvalidNullTime(t *testing.T) {
-	now := time.Now()
 	invalid := NullTime{pq.NullTime{Valid: false}}
-	valid := NullTime{pq.NullTime{Time: now, Valid: true}}
 
+	sql, _, err := Interpolate("SELECT * FROM foo WHERE invalid = $1", []interface{}{invalid})
+	assert.NoError(t, err)
+	assert.Equal(t, stripWS("SELECT * FROM foo WHERE invalid=NULL"), stripWS(sql))
+}
+
+func TestInterpolateValidNullTime(t *testing.T) {
+	now := time.Now()
+	valid := NullTime{pq.NullTime{Time: now, Valid: true}}
 	sql, _, err := Interpolate("SELECT * FROM foo WHERE valid = $1", []interface{}{valid})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "SELECT * FROM foo WHERE valid = '"+valid.Time.Format(time.RFC3339Nano)+"'", sql)
-	sql, _, err = Interpolate("SELECT * FROM foo WHERE invalid = $1", []interface{}{invalid})
-	assert.NoError(t, err)
-	assert.Equal(t, stripWS("SELECT * FROM foo WHERE invalid=NULL"), stripWS(sql))
 }

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"bytes"
 	"math/rand"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -103,4 +104,42 @@ func (pd *Postgres) WriteIdentifier(buf common.BufferWriter, ident string) {
 	buf.WriteRune('"')
 	buf.WriteString(ident)
 	buf.WriteRune('"')
+}
+
+// WriteFormattedTime formats t into a format postgres understands.
+// Taken with gratitude from pq: https://github.com/lib/pq/blob/b269bd035a727d6c1081f76e7a239a1b00674c40/encode.go#L403
+func (pd *Postgres) WriteFormattedTime(buf common.BufferWriter, t time.Time) {
+	buf.WriteRune('\'')
+	defer buf.WriteRune('\'')
+	// XXX: This doesn't currently deal with infinity values
+
+	// Need to send dates before 0001 A.D. with " BC" suffix, instead of the
+	// minus sign preferred by Go.
+	// Beware, "0000" in ISO is "1 BC", "-0001" is "2 BC" and so on
+	bc := false
+	if t.Year() <= 0 {
+		// flip year sign, and add 1, e.g: "0" will be "1", and "-10" will be "11"
+		t = t.AddDate((-t.Year())*2+1, 0, 0)
+		bc = true
+	}
+	buf.WriteString(t.Format(time.RFC3339Nano))
+
+	_, offset := t.Zone()
+	offset = offset % 60
+	if offset != 0 {
+		// RFC3339Nano already printed the minus sign
+		if offset < 0 {
+			offset = -offset
+		}
+
+		buf.WriteRune(':')
+		if offset < 10 {
+			buf.WriteRune('0')
+		}
+		buf.WriteString(strconv.FormatInt(int64(offset), 10))
+	}
+
+	if bc {
+		buf.WriteString(" BC")
+	}
 }

--- a/types.go
+++ b/types.go
@@ -37,8 +37,6 @@ const DEFAULT = UnsafeString("DEFAULT")
 // NOW SQL value
 const NOW = UnsafeString("NOW()")
 
-var timeFormat = "2006-01-02 15:04:05Z"
-
 // NullString is a type that can be null or a string
 type NullString struct {
 	sql.NullString
@@ -264,13 +262,4 @@ func (j *JSON) Scan(src interface{}) error {
 // Unmarshal unmarshal's the json in j to v, as in json.Unmarshal.
 func (j *JSON) Unmarshal(v interface{}) error {
 	return json.Unmarshal([]byte(*j), v)
-}
-
-// UnsafeString returns an escaped time format or NULL constant for
-// use by Interpolate.
-func (n NullTime) UnsafeString() (UnsafeString, error) {
-	if n.Valid {
-		return UnsafeString("'" + n.Time.Format(time.RFC3339Nano) + "'"), nil
-	}
-	return "NULL", nil
 }

--- a/types.go
+++ b/types.go
@@ -20,12 +20,6 @@ type Interpolator interface {
 	Interpolate() (string, error)
 }
 
-// UnsafeStringer is used in interpolation to return a string
-// that should not be escaped.
-type UnsafeStringer interface {
-	UnsafeString() (UnsafeString, error)
-}
-
 // Value implements a valuer for compatibility
 func (u UnsafeString) Value() (driver.Value, error) {
 	panic("UnsafeStrings and its constants NOW, DEFAULT ... are disabled when EnableInterpolation==false")


### PR DESCRIPTION
By borrowing the same function the pq driver uses to format `time.Time` values, we can ensure that all `time.Time`s being sent to the database are formatted consistently, whether `dat.EnableInterpolation` is on or not.

This works for all `time.Time` values, whether produced by `dat.NullTime`, `pq.NullTime`, or `time.Time`.

This grew out of the discussion on #22.