### PR TITLE
Remove Limit(1) from DeleteBuilder query

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,6 @@ result, err := DB.
 result, err = DB.
     DeleteFrom("posts").
     Where("id = $1", otherPost.ID).
-    Limit(1).
     Exec()
 ```
 


### PR DESCRIPTION
Couldn't find it in https://github.com/mgutz/dat/blob/v1/delete.go.  This code doesn't compile on master.

Does it seem sound @mgutz ?

Thanks!
