### PR TITLE
Add flag to skip version detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ func init() {
     // Should be disabled in production/release builds.
     dat.Strict = false
 
+    // set this to disable automatic version detection
+    dat.SkipVersionDetection = false
+
     // Log any query over 10ms as warnings. (optional)
     runner.LogQueriesThreshold = 10 * time.Millisecond
 

--- a/init.go
+++ b/init.go
@@ -15,6 +15,9 @@ var Strict = false
 // EnableInterpolation enables or disable interpolation
 var EnableInterpolation = false
 
+// SkipVersionDetection prevents automatic version detection
+var SkipVersionDetection = false
+
 // maxLookup is the max lookup index for predefined lookup tables
 const maxLookup = 100
 

--- a/sqlx-runner/db.go
+++ b/sqlx-runner/db.go
@@ -44,6 +44,10 @@ func pgMustNotAllowEscapeSequence(conn *DB) {
 }
 
 func pgSetVersion(db *DB) {
+	if dat.SkipVersionDetection {
+		return
+	}
+
 	err := db.
 		SQL("SHOW server_version_num").
 		QueryScalar(&db.Version)

--- a/sqlx-runner/db_test.go
+++ b/sqlx-runner/db_test.go
@@ -3,10 +3,18 @@ package runner
 import (
 	"testing"
 
+	"gopkg.in/mgutz/dat.v1"
 	"gopkg.in/stretchr/testify.v1/assert"
 )
 
 func TestVersion(t *testing.T) {
 	// require at least 9.3+ for testing
 	assert.True(t, testDB.Version > 90300)
+}
+
+func TestSkipVersionLookup(t *testing.T) {
+	dat.SkipVersionDetection = true
+	versionTestDB := NewDB(sqlDB, "postgres")
+	assert.True(t, versionTestDB.Version == 0)
+	dat.SkipVersionDetection = false
 }

--- a/struct_mapping.go
+++ b/struct_mapping.go
@@ -2,8 +2,8 @@ package dat
 
 import (
 	"fmt"
-	"reflect"
 	"github.com/mgutz/str"
+	"reflect"
 
 	"gopkg.in/mgutz/dat.v1/reflectx"
 )


### PR DESCRIPTION
CockroachDB supports the PostgreSQL wire protocol, and both libpq and sqlx will transparently connect to an instance. Unfortunately, dat _can't_ connect, because it automatically calls `SHOW server_version_number;` on connection, and cockroach doesn't set that variable. This makes me sad, because CockroachDB and dat are both awesome, and it would be great to use them together.

This PR adds a flag `dat.SkipVersionDetection`, set to false by default, which allows users to skip the initial version detection. As far as I can tell, setting that flag is all that is needed to allow dat to connect to cockroach as well as postgres.