### PR TITLE
UpdateBuilder ToSQL handles # of params >= maxLookup

### DIFF
--- a/update.go
+++ b/update.go
@@ -174,15 +174,11 @@ func (b *UpdateBuilder) ToSQL() (string, []interface{}) {
 			placeholderStartPos += int64(len(e.Args))
 		} else {
 			// TOOD
-			if i < maxLookup {
+			if placeholderStartPos < maxLookup {
 				buf.WriteString(equalsPlaceholderTab[placeholderStartPos])
 			} else {
-				if placeholderStartPos < maxLookup {
-					buf.WriteString(equalsPlaceholderTab[placeholderStartPos])
-				} else {
-					buf.WriteString(" = $")
-					buf.WriteString(strconv.FormatInt(placeholderStartPos, 10))
-				}
+				buf.WriteString(" = $")
+				buf.WriteString(strconv.FormatInt(placeholderStartPos, 10))
 			}
 			placeholderStartPos++
 			args = append(args, c.value)

--- a/update_test.go
+++ b/update_test.go
@@ -25,45 +25,45 @@ func BenchmarkUpdateValueMapSql(b *testing.B) {
 func TestUpdateAllToSql(t *testing.T) {
 	sql, args := Update("a").Set("b", 1).Set("c", 2).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "b", "c"))
-	assert.Equal(t, args, []interface{}{1, 2})
+	assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "b", "c"), sql)
+	assert.Equal(t, []interface{}{1, 2}, args)
 }
 
 func TestUpdateSingleToSql(t *testing.T) {
 	sql, args := Update("a").Set("b", 1).Set("c", 2).Where("id = $1", 1).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "b", "c"))
-	assert.Equal(t, args, []interface{}{1, 2, 1})
+	assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "b", "c"), sql)
+	assert.Equal(t, []interface{}{1, 2, 1}, args)
 }
 
 func TestUpdateSetMapToSql(t *testing.T) {
 	sql, args := Update("a").SetMap(map[string]interface{}{"b": 1, "c": 2}).Where("id = $1", 1).ToSQL()
 
 	if sql == quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "b", "c") {
-		assert.Equal(t, args, []interface{}{1, 2, 1})
+		assert.Equal(t, []interface{}{1, 2, 1}, args)
 	} else {
-		assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "c", "b"))
-		assert.Equal(t, args, []interface{}{2, 1, 1})
+		assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2 WHERE (id = $3)`, "c", "b"), sql)
+		assert.Equal(t, []interface{}{2, 1, 1}, args)
 	}
 }
 
 func TestUpdateSetExprToSql(t *testing.T) {
 	sql, args := Update("a").Set("foo", 1).Set("bar", Expr("COALESCE(bar, 0) + 1")).Where("id = $1", 9).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = COALESCE(bar, 0) + 1 WHERE (id = $2)`, "foo", "bar"))
-	assert.Equal(t, args, []interface{}{1, 9})
+	assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1, %s = COALESCE(bar, 0) + 1 WHERE (id = $2)`, "foo", "bar"), sql)
+	assert.Equal(t, []interface{}{1, 9}, args)
 
 	sql, args = Update("a").Set("foo", 1).Set("bar", Expr("COALESCE(bar, 0) + $1", 2)).Where("id = $1", 9).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = COALESCE(bar, 0) + $2 WHERE (id = $3)`, "foo", "bar"))
-	assert.Equal(t, args, []interface{}{1, 2, 9})
+	assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1, %s = COALESCE(bar, 0) + $2 WHERE (id = $3)`, "foo", "bar"), sql)
+	assert.Equal(t, []interface{}{1, 2, 9}, args)
 }
 
 func TestUpdateTenStaringFromTwentyToSql(t *testing.T) {
 	sql, args := Update("a").Set("b", 1).Limit(10).Offset(20).ToSQL()
 
-	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1 LIMIT 10 OFFSET 20`, "b"))
-	assert.Equal(t, args, []interface{}{1})
+	assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1 LIMIT 10 OFFSET 20`, "b"), sql)
+	assert.Equal(t, []interface{}{1}, args)
 }
 
 func TestUpdateWhitelist(t *testing.T) {
@@ -77,8 +77,8 @@ func TestUpdateWhitelist(t *testing.T) {
 		SetWhitelist(sr, "user_id", "other").
 		ToSQL()
 
-	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "user_id", "other"))
-	checkSliceEqual(t, args, []interface{}{2, false})
+	assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "user_id", "other"), sql)
+	checkSliceEqual(t, []interface{}{2, false}, args)
 }
 
 func TestUpdateBlacklist(t *testing.T) {
@@ -87,15 +87,15 @@ func TestUpdateBlacklist(t *testing.T) {
 		SetBlacklist(sr, "something_id").
 		ToSQL()
 
-	assert.Equal(t, sql, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "user_id", "other"))
-	checkSliceEqual(t, args, []interface{}{2, false})
+	assert.Equal(t, quoteSQL(`UPDATE "a" SET %s = $1, %s = $2`, "user_id", "other"), sql)
+	checkSliceEqual(t, []interface{}{2, false}, args)
 }
 
 func TestUpdateWhereExprSql(t *testing.T) {
 	expr := Expr("id=$1", 100)
 	sql, args := Update("a").Set("b", 10).Where(expr).ToSQL()
-	assert.Equal(t, sql, `UPDATE "a" SET "b" = $1 WHERE (id=$2)`)
-	assert.Exactly(t, args, []interface{}{10, 100})
+	assert.Equal(t, `UPDATE "a" SET "b" = $1 WHERE (id=$2)`, sql)
+	assert.Exactly(t, []interface{}{10, 100}, args)
 }
 
 func TestUpdateBeyondMaxLookup(t *testing.T) {


### PR DESCRIPTION
There was no need to check against i in the loop:

- i < maxLookup could happen even if placeholderStartPos >= maxLookup, if the setClauses contained expressions with multiple parameters. So the condition was dangerous in general.
- In the normal case (one parameter per iteration), this was breaking at the boundary because placeholderStartPos == i + 1 at the start of each iteration through the loop, so that when maxLookup == 100 and i == 99, then placeholderStartPos == 100, breaking on the use of equalsPlaceholderTab with index out of range.
- The condition that previously was i >= maxLookup and now applies always for non-expressions does the right thing in all cases, as it guards against the actual value of placeholderStartPos.