### PR TITLE
Add Vector call to JSQL/SelectDoc

### DIFF
--- a/dat/jsql.go
+++ b/dat/jsql.go
@@ -70,7 +70,7 @@ func (b *JSQLBuilder) Many(column string, sqlOrBuilder interface{}, a ...interfa
 	return b
 }
 
-// Vector loads a sub query resulting in an array of rows as an alias.
+// Vector loads a sub query resulting in an array of homogeneous scalars as an alias.
 func (b *JSQLBuilder) Vector(column string, sqlOrBuilder interface{}, a ...interface{}) *JSQLBuilder {
 	if b.err != nil {
 		return b

--- a/dat/jsql_test.go
+++ b/dat/jsql_test.go
@@ -45,3 +45,28 @@ func TestJSQLMany(t *testing.T) {
 	assert.Equal(t, stripWS(expected), stripWS(sql))
 	assert.Equal(t, []interface{}{42, 100}, args)
 }
+
+func TestJSQLVector(t *testing.T) {
+	sql, args, err := JSQL("SELECT name FROM users WHERE id=$1", 42).
+		Many("hobbies", SQL("SELECT * FROM hobbies WHERE id=$1", 100)).
+		Vector("child_ages", SQL("SELECT age FROM users WHERE parent_id=$1", 142)).
+		ToSQL()
+	assert.NoError(t, err)
+
+	expected := `
+		SELECT row_to_json(dat__item.*)
+		FROM (
+			SELECT
+				(SELECT array_agg(dat__hobbies.*) FROM (SELECT * FROM hobbies WHERE id = $2) AS dat__hobbies) AS "hobbies",
+				(SELECT array_agg(dat__child_ages.dat__scalar) FROM (SELECT age FROM users WHERE parent_id=$3) AS dat__child_ages (dat__scalar)) AS "child_ages",
+				name
+			FROM
+				users
+			WHERE
+				id=$1
+		) as dat__item
+	`
+
+	assert.Equal(t, stripWS(expected), stripWS(sql))
+	assert.Equal(t, []interface{}{42, 100, 142}, args)
+}

--- a/dat/select_doc.go
+++ b/dat/select_doc.go
@@ -64,7 +64,7 @@ func (b *SelectDocBuilder) Many(column string, sqlOrBuilder interface{}, a ...in
 	return b
 }
 
-// Vector loads a sub query resulting in an array of homogenous scalars as an alias.
+// Vector loads a sub query resulting in an array of homogeneous scalars as an alias.
 func (b *SelectDocBuilder) Vector(column string, sqlOrBuilder interface{}, a ...interface{}) *SelectDocBuilder {
 	switch t := sqlOrBuilder.(type) {
 	default:

--- a/dat/select_doc.go
+++ b/dat/select_doc.go
@@ -8,11 +8,12 @@ type subInfo struct {
 // SelectDocBuilder builds SQL that returns a JSON row.
 type SelectDocBuilder struct {
 	*SelectBuilder
-	subQueriesMany []*subInfo
-	subQueriesOne  []*subInfo
-	innerSQL       *Expression
-	isParent       bool
-	err            error
+	subQueriesMany   []*subInfo
+	subQueriesVector []*subInfo
+	subQueriesOne    []*subInfo
+	innerSQL         *Expression
+	isParent         bool
+	err              error
 }
 
 // NewSelectDocBuilder creates an instance of SelectDocBuilder.
@@ -59,6 +60,40 @@ func (b *SelectDocBuilder) Many(column string, sqlOrBuilder interface{}, a ...in
 		b.subQueriesMany = append(b.subQueriesMany, &subInfo{Expr(sql, args...), column})
 	case string:
 		b.subQueriesMany = append(b.subQueriesMany, &subInfo{Expr(t, a...), column})
+	}
+	return b
+}
+
+// Vector loads a sub query resulting in an array of homogenous scalars as an alias.
+func (b *SelectDocBuilder) Vector(column string, sqlOrBuilder interface{}, a ...interface{}) *SelectDocBuilder {
+	switch t := sqlOrBuilder.(type) {
+	default:
+		b.err = NewError("SelectDocBuilder.ManyScalars: sqlOrbuilder accepts only {string, Builder, *SelectDocBuilder} type")
+	case *JSQLBuilder:
+		t.isParent = false
+		sql, args, err := t.ToSQL()
+		if err != nil {
+			b.err = err
+			return b
+		}
+		b.subQueriesVector = append(b.subQueriesVector, &subInfo{Expr(sql, args...), column})
+	case *SelectDocBuilder:
+		t.isParent = false
+		sql, args, err := t.ToSQL()
+		if err != nil {
+			b.err = err
+			return b
+		}
+		b.subQueriesVector = append(b.subQueriesVector, &subInfo{Expr(sql, args...), column})
+	case Builder:
+		sql, args, err := t.ToSQL()
+		if err != nil {
+			b.err = err
+			return b
+		}
+		b.subQueriesVector = append(b.subQueriesVector, &subInfo{Expr(sql, args...), column})
+	case string:
+		b.subQueriesVector = append(b.subQueriesVector, &subInfo{Expr(t, a...), column})
 	}
 	return b
 }
@@ -182,6 +217,17 @@ func (b *SelectDocBuilder) ToSQL() (string, []interface{}, error) {
 		buf.WriteString(sub.alias)
 		buf.WriteString(") AS ")
 		writeQuotedIdentifier(buf, sub.alias)
+	}
+
+	for _, sub := range b.subQueriesVector {
+		buf.WriteString(", (SELECT array_agg(dat__")
+		buf.WriteString(sub.alias)
+		buf.WriteString(".dat__scalar) FROM (")
+		sub.WriteRelativeArgs(buf, &args, &placeholderStartPos)
+		buf.WriteString(") AS dat__")
+		buf.WriteString(sub.alias)
+		buf.WriteString("(dat__scalar)) AS ")
+		Dialect.WriteIdentifier(buf, sub.alias)
 	}
 
 	for _, sub := range b.subQueriesOne {

--- a/dat/select_doc_test.go
+++ b/dat/select_doc_test.go
@@ -30,6 +30,7 @@ func TestSelectDocSQLDocs(t *testing.T) {
 	sql, args, err := SelectDoc("b", "c").
 		Many("f", `SELECT g, h FROM f WHERE id= $1`, 4).
 		Many("x", `SELECT id, y, z FROM x`).
+		Vector("y", `SELECT id FROM x`).
 		From("a").
 		Where("d=$1", 4).
 		ToSQL()
@@ -42,7 +43,8 @@ func TestSelectDocSQLDocs(t *testing.T) {
 			b,
 			c,
 			(SELECT array_agg(dat__f.*) FROM (SELECT g,h FROM f WHERE id=$1) AS dat__f) AS "f",
-			(SELECT array_agg(dat__x.*) FROM (SELECT id,y,z FROM x) AS dat__x) AS "x"
+			(SELECT array_agg(dat__x.*) FROM (SELECT id,y,z FROM x) AS dat__x) AS "x",
+			(SELECT array_agg(dat__y.dat__scalar) FROM (SELECT id FROM x) AS dat__y (dat__scalar)) AS "y"
 		FROM a
 		WHERE (d=$2)
 	) as dat__item


### PR DESCRIPTION
This function allows the caller to fill an array of homogeneous scalars with data, rather than requiring an array of structs containing single members.