### PR TITLE
Change import paths to fix 'no buildable Go source files error' re: logxi

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,57 +1,53 @@
-hash: e3f29af646fbe700dd82d6f6d7193c0a7a18ad9b6db640b68d36974595e096b5
-updated: 2017-03-27T07:02:57.219253178-07:00
+hash: 10ccf307f8c5d739d15c9d9b0e16dbef375e9343726edc87ce1e0d5c1167aace
+updated: 2017-05-11T13:38:39.896973927-07:00
 imports:
 - name: github.com/cenkalti/backoff
-  version: c29158af31815ccc31ca29c86c121bc39e00d3d8
+  version: 32cd0c5b3aef12c76ed64aaf678f6c79736be7dc
 - name: github.com/garyburd/redigo
-  version: b8dc90050f24c1a73a52f107f3f575be67b21b7c
+  version: 8873b2f1995f59d4bcdd2b0dc9858e2cb9bf0c13
   subpackages:
   - internal
   - redis
 - name: github.com/howeyc/gopass
-  version: 66487b23f2880ba32e185121d2cd51a338ea069a
+  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/jmoiron/sqlx
-  version: a7f971fe8ea891a1a74ddb40c623f5722e28e8a8
+  version: d9bd385d68c068f1fabb5057e3dedcbcbb039d0f
   subpackages:
   - reflectx
 - name: github.com/lib/pq
-  version: ee1442bda7bd1b6a84e913bdb421cb1874ec629d
+  version: 2704adc878c21e1329f46f6e56a1c387d788ff94
   subpackages:
   - oid
 - name: github.com/mattn/go-colorable
-  version: ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8
+  version: ded68f7a9561c023e790de24279db7ebf473ea80
 - name: github.com/mattn/go-isatty
-  version: 3a115632dcd687f9c8cd01679c83a06a0e21c1f3
+  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mgutz/ansi
-  version: c286dcecd19ff979eeb73ea444e479b903f2cfcb
-- name: github.com/mgutz/jo
-  version: 0b027231853f934a4fe43d82d269c16adc54a225
+  version: 9520e82c474b0a04dd04f8a40959027271bab992
+- name: github.com/mgutz/logxi
+  version: aebf8a7d67ab4625e0fd4a665766fef9a709161b
   subpackages:
   - v1
-- name: github.com/mgutz/logxi
-  version: 3753102df44ef6dc2552aea65b9666b593d68663
 - name: github.com/mgutz/minimist
   version: 39eb8cf573ca29344bd7d7e6ba4d7febdebd37a9
 - name: github.com/mgutz/str
   version: 968bf66e3da857419e4f6e71b2d5c9ae95682dc4
 - name: github.com/mgutz/to
-  version: 2a0bcba0661696e339461f5efb2273f4459dd1b9
+  version: 00c06406c2dd2e011f153a6502a21473676db33f
 - name: github.com/MichaelTJones/walk
-  version: 3af09438b0ab0e8f296410bfa646a7e635ea1fc0
-- name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: 4748e29d5718c2df4028a6543edf86fd8cc0f881
 - name: github.com/nozzle/throttler
   version: d9b45f19996c645d38c9266d1f5cf1990e930119
 - name: github.com/pmylund/go-cache
   version: 1881a9bccb818787f68c52bfba648c6cf34c34fa
 - name: github.com/satori/go.uuid
-  version: f9ab0dce87d815821e221626b772e3475a0d2749
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: golang.org/x/crypto
-  version: 5bcd134fee4dd1475da17714aac19c0aa0142e2f
+  version: 122d919ec1efcfb58483215da23f815853e24b81
   subpackages:
   - ssh/terminal
 - name: golang.org/x/sys
-  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
   subpackages:
   - unix
 - name: gopkg.in/godo.v2
@@ -61,16 +57,20 @@ imports:
   - util
   - watcher
   - watcher/fswatch
-- name: gopkg.in/stretchr/testify.v1
-  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
-  subpackages:
-  - assert
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
+- name: github.com/mgutz/jo
+  version: 0b027231853f934a4fe43d82d269c16adc54a225
+  subpackages:
+  - v1
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: gopkg.in/stretchr/testify.v1
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,3 +20,5 @@ import:
   subpackages:
   - assert
 - package: github.com/mgutz/logxi
+  subpackages:
+  - v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,24 +1,34 @@
 package: gopkg.in/mgutz/dat.v1
 import:
 - package: github.com/cenkalti/backoff
+  version: ^1.0.0
 - package: github.com/garyburd/redigo
+  version: ^1.0.0
   subpackages:
   - redis
 - package: github.com/jmoiron/sqlx
 - package: github.com/lib/pq
 - package: github.com/mgutz/ansi
-- package: github.com/mgutz/jo
+- package: github.com/mgutz/logxi
+  version: ^1.0.0
   subpackages:
   - v1
 - package: github.com/mgutz/str
+  version: ^1.2.0
 - package: github.com/pmylund/go-cache
+  version: ^2.0.0
 - package: github.com/satori/go.uuid
+  version: ^1.1.0
 - package: gopkg.in/godo.v2
+  version: ^2.0.9
   subpackages:
   - util
-- package: gopkg.in/stretchr/testify.v1
-  subpackages:
-  - assert
-- package: github.com/mgutz/logxi
+testImport:
+- package: github.com/mgutz/jo
+  version: master
   subpackages:
   - v1
+- package: gopkg.in/stretchr/testify.v1
+  version: ^1.1.4
+  subpackages:
+  - assert

--- a/init.go
+++ b/init.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/mgutz/logxi"
+	logxi "github.com/mgutz/logxi/v1"
 )
 
 var logger logxi.Logger

--- a/kvs/init.go
+++ b/kvs/init.go
@@ -1,6 +1,6 @@
 package kvs
 
-import "github.com/mgutz/logxi"
+import logxi "github.com/mgutz/logxi/v1"
 
 var logger logxi.Logger
 

--- a/sqlx-runner/init.go
+++ b/sqlx-runner/init.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/mgutz/logxi"
+	logxi "github.com/mgutz/logxi/v1"
 	"gopkg.in/mgutz/dat.v1"
 	"gopkg.in/mgutz/dat.v1/kvs"
 	"gopkg.in/mgutz/dat.v1/postgres"

--- a/sqlx-runner/init_test.go
+++ b/sqlx-runner/init_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/mgutz/logxi"
+	logxi "github.com/mgutz/logxi/v1"
 
 	"gopkg.in/mgutz/dat.v1"
 	"gopkg.in/mgutz/dat.v1/kvs"


### PR DESCRIPTION
Fixes #66 
Currently, the project is unusable with current `glide.lock`. The root cause is that the current `glide.lock` represents a dependency graph that is not compatible with `v1` changes introduced here: https://github.com/mgutz/dat/commit/f2918ee2c9dd12bc7f27302aa28333ffcabc24d2#diff-33921aca24f9053a9a0b9e289014da32R3

l have:
* updated the `logx`i imports in dat.v1 to include the `v1` package
* downgraded the `jo` dependency back to the version **with** a `v1` package, as dat imports still rely on that package.