### PR TITLE
add support for context

### DIFF
--- a/dat/execer.go
+++ b/dat/execer.go
@@ -1,6 +1,9 @@
 package dat
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Result serves the same purpose as sql.Result. Defining
 // it for the package avoids tight coupling with database/sql.
@@ -13,6 +16,7 @@ type Result struct {
 type Execer interface {
 	Cache(id string, ttl time.Duration, invalidate bool) Execer
 	Timeout(time.Duration) Execer
+	Context(context.Context) Execer
 	Interpolate() (string, []interface{}, error)
 	Exec() (*Result, error)
 
@@ -35,6 +39,10 @@ func (nop *disconnectedExecer) Cache(id string, ttl time.Duration, invalidate bo
 }
 
 func (nop *disconnectedExecer) Timeout(time.Duration) Execer {
+	return nil
+}
+
+func (nop *disconnectedExecer) Context(context.Context) Execer {
 	return nil
 }
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 96b33372e619c3e4f2c39384e9577881d2a6ba9c22ac6eb04cfd680471f8dc84
-updated: 2016-06-04T15:45:36.594344149-07:00
+updated: 2017-06-23T10:43:54.561604473+02:00
 imports:
 - name: github.com/cenkalti/backoff
   version: c29158af31815ccc31ca29c86c121bc39e00d3d8
@@ -11,7 +11,7 @@ imports:
 - name: github.com/howeyc/gopass
   version: 66487b23f2880ba32e185121d2cd51a338ea069a
 - name: github.com/jmoiron/sqlx
-  version: a7f971fe8ea891a1a74ddb40c623f5722e28e8a8
+  version: 8ed836a8adb659e8492bcaa49e0880bb84075fe2
   subpackages:
   - reflectx
 - name: github.com/lib/pq

--- a/sqlx-runner/execer.go
+++ b/sqlx-runner/execer.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -24,6 +25,8 @@ type Execer struct {
 	// uuid is prepended into the SQL for the query to be searched
 	// in pg_stat_activity, used by timeout logic
 	queryID string
+
+	ctx context.Context
 }
 
 const queryIDPrefix = "--dat:qid="
@@ -33,6 +36,7 @@ func NewExecer(database database, builder dat.Builder) *Execer {
 	return &Execer{
 		database: database,
 		builder:  builder,
+		ctx:      context.Background(),
 	}
 }
 
@@ -52,6 +56,12 @@ func (ex *Execer) Timeout(timeout time.Duration) dat.Execer {
 	} else {
 		ex.queryID = ""
 	}
+	return ex
+}
+
+// Context sets the context for current query.
+func (ex *Execer) Context(ctx context.Context) dat.Execer {
+	ex.ctx = ctx
 	return ex
 }
 


### PR DESCRIPTION
allow to pass context.Context to the sql package, using the *Context funcs on sqlx
needs a more recent version of sqlx - see https://github.com/jmoiron/sqlx/pull/270