### PR TITLE
Fix panic on NullTime.UnmarshalJSON

### DIFF
--- a/types.go
+++ b/types.go
@@ -182,6 +182,9 @@ func (n *NullTime) UnmarshalJSON(b []byte) error {
 	}
 
 	s := string(b)
+	if len(s) < 2 {
+		return logger.Error("Cannot parse time", "time", s)
+	}
 	s = s[1 : len(s)-1]
 	for _, format := range formats {
 		t, err := time.Parse(format, s)


### PR DESCRIPTION
```go
type WithDate struct {
	Time dat.NullTime `json:"time"`
}

func TestParseNumberAsDate(t *testing.T) {
	data := `{"time":5}`
	result := &WithDate{}
	json.Unmarshal([]byte(data), result) // PANIC!
}
```