### PR TITLE
make pending transactions timeout configurable

### DIFF
--- a/sqlx-runner/init.go
+++ b/sqlx-runner/init.go
@@ -16,6 +16,10 @@ var logger log.Logger
 // LogQueriesThreshold is the threshold for logging "slow" queries
 var LogQueriesThreshold time.Duration
 
+// PendingTransactionsTimeout is the timeout for pending transactions
+// (used when the strict mode is enabled)
+var PendingTransactionsTimeout = 1 * time.Minute
+
 func init() {
 	dat.Dialect = postgres.New()
 	logger = log.New("dat:sqlx")

--- a/sqlx-runner/tx.go
+++ b/sqlx-runner/tx.go
@@ -35,7 +35,7 @@ type Tx struct {
 func WrapSqlxTx(tx *sqlx.Tx) *Tx {
 	newtx := &Tx{Tx: tx, Queryable: &Queryable{tx}}
 	if dat.Strict {
-		time.AfterFunc(1*time.Minute, func() {
+		time.AfterFunc(PendingTransactionsTimeout, func() {
 			if !newtx.IsRollbacked && newtx.state == txPending {
 				panic("A database transaction was not closed!")
 			}


### PR DESCRIPTION
when the strict mode is enabled, pending transactions timeouts after 1 minute (hardcoded).
make it configurable (default to 1 minute)