### PR TITLE
Wrapping guid.NewV4() to get prior behavior returning a single value.

### DIFF
--- a/sqlx-runner/exec.go
+++ b/sqlx-runner/exec.go
@@ -718,5 +718,5 @@ func (ex *Execer) queryObject(dest interface{}) error {
 
 // uuid generates a UUID.
 func uuid() string {
-	return fmt.Sprintf("%s", guid.NewV4())
+	return fmt.Sprintf("%s", guid.Must(guid.NewV4()))
 }


### PR DESCRIPTION
Recently, the go.uuid library was modified to return a string, and an error when generating UUIDs. See [1]. For backwards compatibility, a Must func helper is provided which panics if there are any errors, reovering the prior behavior.

[1] https://github.com/satori/go.uuid/commit/0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c